### PR TITLE
VLN-507: Set explicit permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - "releases/*"
+permissions:
+  contents: read
 
 jobs:
   build-lint-test:


### PR DESCRIPTION
## Summary

- `.github/workflows/ci.yml`: Added a top-level permissions block granting only contents: read to restrict the GITHUB_TOKEN to the minimum needed for checkout.